### PR TITLE
[TASK] Keep uppercase characters in rst titles

### DIFF
--- a/Resources/Public/js/WMDB.Forger.Rst.js
+++ b/Resources/Public/js/WMDB.Forger.Rst.js
@@ -138,7 +138,7 @@ $(document).ready(function () {
 
 String.prototype.toUpperCamelCase = function () {
 	return this.replace(/\w\S*/g, function (txt) {
-		return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+		return txt.charAt(0).toUpperCase() + txt.substr(1);
 	}).replace(/\s/g, '');
 };
 


### PR DESCRIPTION
If a title for a rst file already contains uppercase characters,
these should not be removed, e.g. to keep "TypoScript" as is.